### PR TITLE
Added link to 制約付き解析 at mecab.googlecode to documentation.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -213,8 +213,8 @@ The ``-F`` short form of the ``--node-format`` option is used here::
 
 ----
 
-Using constraint parsing (制約付き解析), it is possible to pass hints to 
-``MeCab`` on　which words it should treat as a single token. 
+Using `constraint parsing`_ (制約付き解析), it is possible to pass hints
+to ``MeCab`` on　which words it should treat as a single token. 
 
 For example, without any special hints::
 
@@ -237,24 +237,8 @@ But you can provide ``MeCab`` with a regular expression pattern as a hint on
 where and how to mark the boundaries of a morpheme when parsing. This is 
 known as boundary constraint parsing. Pass in the regular expression as a
 ``str`` or compiled ``regex`` using the ``boundary_constraints`` keyword 
-argument::
+argument.
 
-    with MeCab() as nm:
-
-        text = 'にわにはにわにわとりがいる。'
-        pattern = 'にわとり|はにわ|にわ'
-
-        print(nm.parse(text, boundary_constraints=pattern))
-    ...
-    にわ	名詞,一般,*,*,*,*,*
-    に	助詞,格助詞,一般,*,*,*,に,ニ,ニ
-    はにわ	名詞,一般,*,*,*,*,はにわ,ハニワ,ハニワ
-    にわとり	名詞,一般,*,*,*,*,にわとり,ニワトリ,ニワトリ
-    が	助詞,格助詞,一般,*,*,*,が,ガ,ガ
-    いる	動詞,自立,*,*,一段,基本形,いる,イル,イル
-    。	記号,句点,*,*,*,*,。,。,。
-    EOS
-        
 Note that any such tokens matching the ``boundary_constraints`` pattern that
 cannot be found in any of the dictionaries used will have an unknown ``stat``
 status value of 1. Here we illustrate that by using a combination of output
@@ -330,6 +314,7 @@ the ``LICENSE`` file for further details.
 .. _Python 3.4: https://docs.python.org/dev/whatsnew/3.4.html 
 .. _NLTK3's lead: https://github.com/nltk/nltk/wiki/Porting-your-code-to-NLTK-3.0
 .. _Python with-statement: https://www.python.org/dev/peps/pep-0343/
+.. _constraint parsing: https://mecab.googlecode.com/svn/trunk/mecab/doc/partial.html
 .. _project Wiki: https://github.com/buruzaemon/natto-py/wiki 
 .. _project's notebooks directory: https://github.com/buruzaemon/natto-py/tree/master/notebooks
 .. _API documentation on Read the Docs: http://natto-py.readthedocs.org/en/master/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -214,8 +214,8 @@ The ``-F`` short form of the ``--node-format`` option is used here::
 
 ----
 
-Using constraint parsing (制約付き解析), it is possible to pass hints to 
-``MeCab`` on　which words it should treat as a single token. 
+Using `constraint parsing`_ (制約付き解析), it is possible to pass hints
+to ``MeCab`` on　which words it should treat as a single token. 
 
 For example, without any special hints::
 
@@ -238,24 +238,8 @@ But you can provide ``MeCab`` with a regular expression pattern as a hint on
 where and how to mark the boundaries of a morpheme when parsing. This is 
 known as boundary constraint parsing. Pass in the regular expression as a
 ``str`` or compiled ``regex`` using the ``boundary_constraints`` keyword 
-argument::
+argument.
 
-    with MeCab() as nm:
-
-        text = 'にわにはにわにわとりがいる。'
-        pattern = 'にわとり|はにわ|にわ'
-
-        print(nm.parse(text, boundary_constraints=pattern))
-    ...
-    にわ	名詞,一般,*,*,*,*,*
-    に	助詞,格助詞,一般,*,*,*,に,ニ,ニ
-    はにわ	名詞,一般,*,*,*,*,はにわ,ハニワ,ハニワ
-    にわとり	名詞,一般,*,*,*,*,にわとり,ニワトリ,ニワトリ
-    が	助詞,格助詞,一般,*,*,*,が,ガ,ガ
-    いる	動詞,自立,*,*,一段,基本形,いる,イル,イル
-    。	記号,句点,*,*,*,*,。,。,。
-    EOS
-        
 Note that any such tokens matching the ``boundary_constraints`` pattern that
 cannot be found in any of the dictionaries used will have an unknown ``stat``
 status value of 1. Here we illustrate that by using a combination of output
@@ -336,6 +320,7 @@ Documentation
 .. _NLTK3's lead: https://github.com/nltk/nltk/wiki/Porting-your-code-to-NLTK-3.0
 .. _Python with-statement: https://www.python.org/dev/peps/pep-0343/
 .. _project Wiki: https://github.com/buruzaemon/natto-py/wiki 
+.. _constraint parsing: https://mecab.googlecode.com/svn/trunk/mecab/doc/partial.html
 .. _project's notebooks directory: https://github.com/buruzaemon/natto-py/tree/master/notebooks
 .. _git: http://git-scm.com/downloads
 .. _check out the latest code at GitHub: https://github.com/buruzaemon/natto-py


### PR DESCRIPTION
These should the very last set of documentation edits before releasing 0.3.0.