### PR TITLE
Issue 83: surpress GeneratorExit

### DIFF
--- a/natto/mecab.py
+++ b/natto/mecab.py
@@ -390,6 +390,8 @@ class MeCab(object):
                             mnode = MeCabNode(nptr, surf, feat)
                             yield mnode
                         nptr = getattr(nptr, 'next')
+        except GeneratorExit:
+            pass
         except:
             err = self.__mecab.mecab_lattice_strerror(self.lattice)
             raise MeCabError(self.__bytes2str(self.__ffi.string(err)))


### PR DESCRIPTION
Solution to Issue 83 is to explicitly deal with GeneratorExit error that arise when close() is invoked, such as when a break happens during iteration.