### PR TITLE
Remove logging configuration

### DIFF
--- a/natto/mecab.py
+++ b/natto/mecab.py
@@ -11,7 +11,6 @@ from .node import MeCabNode
 from .option_parse import OptionParse
 from .support import string_support, splitter_support
 
-logging.basicConfig()
 logger = logging.getLogger('natto.mecab')
 
 class MeCab(object):


### PR DESCRIPTION
The logger basic configuration should be done by the user application of the library.

Setting the basic configuration inside the library causes the application call to `logging.basicConfig` to be ignored. As a result, when `natto-py` is imported, the default basic configuration is imposed to the whole application.